### PR TITLE
Fix README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ A Streamlit application to help you plan your retirement using Bitcoin as an inv
 
 ## Getting Started
 1. Clone the repository:
-   ```
-   bash
+   ```bash
    git clone https://github.com/Letdown2491/retireonbtc.git
-   cd retire
+   cd retireonbtc
+   ```
 2. Install dependencies:
-   ```
+   ```bash
    pip install -r requirements.txt
-3. Run the application:
    ```
+3. Run the application:
+   ```bash
    streamlit run main.py
+   ```


### PR DESCRIPTION
## Summary
- Complete the git clone snippet with `cd retireonbtc` and close the code block.
- Wrap dependency installation and application run commands in their own fenced bash blocks.
- Proofread instructions for clarity and consistent formatting.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3745cf94483319655046fccab58ad