### PR TITLE
Use timestamped cache for Bitcoin price

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,12 +2,24 @@
 import streamlit as st
 from utils import get_bitcoin_price, initialize_session_state
 from calculations import calculate_bitcoin_needed
-from functools import lru_cache
+from datetime import datetime, timedelta
 
-# Cache the Bitcoin price for 5 minutes to reduce API calls
-@lru_cache(maxsize=None)
+# Cache the Bitcoin price along with a timestamp to reduce API calls
+_price_cache = {"price": None, "timestamp": None}
+_CACHE_DURATION = timedelta(minutes=5)
+
+
 def cached_get_bitcoin_price():
-    return get_bitcoin_price()
+    """Return Bitcoin price, refreshing the cache if it's older than five minutes."""
+    now = datetime.now()
+    if (
+        _price_cache["price"] is None
+        or _price_cache["timestamp"] is None
+        or now - _price_cache["timestamp"] > _CACHE_DURATION
+    ):
+        _price_cache["price"] = get_bitcoin_price()
+        _price_cache["timestamp"] = now
+    return _price_cache["price"]
 
 def validate_inputs(current_age, retirement_age, life_expectancy, monthly_spending):
     """Validate user inputs and return True if all are valid"""


### PR DESCRIPTION
## Summary
- Replace `lru_cache` with manual cache storing price and timestamp
- Refresh Bitcoin price if cached value is older than five minutes
- Clarify comments around caching approach

## Testing
- `python -m py_compile main.py utils.py calculations.py config.py validation.py visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_68a37a2db1888331919e9d452dc531b4