### PR TITLE
Pass cached Bitcoin price to retirement calculations

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -12,10 +12,8 @@ def calculate_total_future_expenses(annual_expense, years, inflation_rate):
     return annual_expense * (((1 + inflation_rate/100)**years - 1) / (inflation_rate/100)) * (1 + inflation_rate/100)
 
 def calculate_bitcoin_needed(monthly_spending, current_age, retirement_age, life_expectancy,
-                           bitcoin_growth_rate, inflation_rate, current_holdings, monthly_investment):
-    """
-    Calculate the Bitcoin needed for retirement considering inflation and growth rates
-    """
+                           bitcoin_growth_rate, inflation_rate, current_holdings, monthly_investment, current_bitcoin_price):
+    """Calculate the Bitcoin needed for retirement considering inflation and growth rates"""
     # Calculate years until retirement and retirement duration
     years_until_retirement = retirement_age - current_age
     retirement_duration = life_expectancy - retirement_age
@@ -27,10 +25,6 @@ def calculate_bitcoin_needed(monthly_spending, current_age, retirement_age, life
     total_retirement_expenses = calculate_total_future_expenses(
         annual_expense_at_retirement, retirement_duration, inflation_rate
     )
-
-    # Get current Bitcoin price
-    from utils import get_bitcoin_price
-    current_bitcoin_price = get_bitcoin_price()
 
     # Calculate future Bitcoin price at retirement
     future_bitcoin_price = current_bitcoin_price * (1 + bitcoin_growth_rate / 100) ** years_until_retirement

--- a/main.py
+++ b/main.py
@@ -134,9 +134,12 @@ def main():
                 'monthly_investment': monthly_investment
             }
 
+            # Get and cache the current Bitcoin price once
+            current_bitcoin_price = cached_get_bitcoin_price()
+
             # Perform the calculation
             bitcoin_needed, life_expectancy, total_bitcoin_holdings, future_investment_value, annual_expense_at_retirement, future_bitcoin_price, total_retirement_expenses = calculate_bitcoin_needed(
-                monthly_spending, current_age, retirement_age, life_expectancy, bitcoin_growth_rate, inflation_rate, current_holdings, monthly_investment
+                monthly_spending, current_age, retirement_age, life_expectancy, bitcoin_growth_rate, inflation_rate, current_holdings, monthly_investment, current_bitcoin_price
             )
 
         years_until_retirement = retirement_age - current_age
@@ -164,7 +167,7 @@ def main():
             col_a, col_b = st.columns(2)
             with col_a:
                 st.write("Years Until Retirement:", f"{years_until_retirement} years")
-                st.write("Current Bitcoin Price:", f"${cached_get_bitcoin_price():,.2f}")
+                st.write("Current Bitcoin Price:", f"${current_bitcoin_price:,.2f}")
                 st.write("Projected Price at Retirement:", f"${future_bitcoin_price:,.2f}")
                 st.write("Bitcoin Needed at Retirement:", f"{bitcoin_needed:.4f} BTC")
             with col_b:


### PR DESCRIPTION
## Summary
- Cache the current Bitcoin price once in `main.py` and reuse it for calculations and display.
- Extend `calculate_bitcoin_needed` to accept the cached price instead of fetching it internally.
- Remove internal price fetch, using the provided price to derive future Bitcoin value.

## Testing
- `python -m py_compile main.py calculations.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a37cd1ce448331bf3c6acc846ddccc