### PR TITLE
Fix spending minimum validation and add regression test

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from validation import validate_inputs
+from config import (
+    DEFAULT_CURRENT_AGE,
+    DEFAULT_RETIREMENT_AGE,
+    DEFAULT_LIFE_EXPECTANCY,
+    DEFAULT_BITCOIN_GROWTH_RATE,
+    DEFAULT_INFLATION_RATE,
+    DEFAULT_CURRENT_HOLDINGS,
+    DEFAULT_MONTHLY_INVESTMENT,
+    SPENDING_MIN,
+)
+
+
+def test_monthly_spending_minimum_passes() -> None:
+    errors = validate_inputs(
+        DEFAULT_CURRENT_AGE,
+        DEFAULT_RETIREMENT_AGE,
+        DEFAULT_LIFE_EXPECTANCY,
+        SPENDING_MIN,
+        DEFAULT_BITCOIN_GROWTH_RATE,
+        DEFAULT_INFLATION_RATE,
+        DEFAULT_CURRENT_HOLDINGS,
+        DEFAULT_MONTHLY_INVESTMENT,
+    )
+
+    assert not any(
+        "Monthly spending" in error for error in errors
+    ), "Monthly spending at SPENDING_MIN should pass validation"
+

--- a/validation.py
+++ b/validation.py
@@ -15,8 +15,8 @@ def validate_inputs(current_age, retirement_age, life_expectancy, monthly_spendi
     if life_expectancy <= retirement_age or not AGE_RANGE[0] <= life_expectancy <= AGE_RANGE[1]:
         errors.append(f"Life expectancy must be greater than retirement age and between {AGE_RANGE[0]} and {AGE_RANGE[1]}")
 
-    if monthly_spending <= SPENDING_MIN:
-        errors.append(f"Monthly spending needs must be positive")
+    if monthly_spending < SPENDING_MIN:
+        errors.append(f"Monthly spending must be at least {SPENDING_MIN}")
 
     if bitcoin_growth_rate < RATE_MIN:
         errors.append("Bitcoin growth rate cannot be negative")


### PR DESCRIPTION
## Summary
- allow monthly spending at minimum threshold by using `< SPENDING_MIN`
- clarify validation error message with required minimum
- add regression test ensuring spending at `SPENDING_MIN` passes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3d70c0afc83319cc683c1ec366cd8