### PR TITLE
Improve price fetch retry logic with session reuse and backoff

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -14,47 +14,56 @@ def initialize_session_state():
     if 'clear_results' not in st.session_state:
         st.session_state.clear_results = False
 
-def get_bitcoin_price(max_attempts=3):
-    """
-    Fetch the current Bitcoin price from DIA API with retry logic.
+def get_bitcoin_price(max_attempts=3, base_delay=2):
+    """Fetch the current Bitcoin price from DIA API with retry logic.
 
     Args:
-        max_attempts (int): Maximum number of attempts to fetch the price
+        max_attempts (int): Maximum number of attempts to fetch the price.
+        base_delay (int | float): Base delay in seconds used for exponential
+            backoff between retry attempts.
 
     Returns:
         tuple: (price, warnings) where price is the current Bitcoin price in USD
-               or fallback price if all attempts fail, and warnings is a list
-               of warning messages generated during the process
+            or fallback price if all attempts fail, and warnings is a list of
+            warning messages generated during the process.
     """
-    dia_api_url = "https://api.diadata.org/v1/assetQuotation/Bitcoin/0x0000000000000000000000000000000000000000"
+    dia_api_url = (
+        "https://api.diadata.org/v1/assetQuotation/Bitcoin/0x0000000000000000000000000000000000000000"
+    )
     timeout = 10  # seconds
     warnings = []
 
-    for attempt in range(max_attempts):
-        try:
-            response = requests.get(dia_api_url, timeout=timeout)
-            response.raise_for_status()
+    with requests.Session() as session:
+        for attempt in range(max_attempts):
+            try:
+                response = session.get(dia_api_url, timeout=timeout)
+                response.raise_for_status()
 
-            data = response.json()
-            current_price = data.get('Price')
+                data = response.json()
+                current_price = data.get("Price")
 
-            if current_price is None or float(current_price) <= 0:
-                raise ValueError("Received invalid price")
+                if current_price is None or float(current_price) <= 0:
+                    raise ValueError("Received invalid price")
 
-            return float(current_price), warnings
+                return float(current_price), warnings
 
-        except requests.exceptions.RequestException as e:
-            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            message = f"[{timestamp}] Attempt {attempt + 1} failed to get Bitcoin price: {str(e)}"
-            logging.warning(message)
-            warnings.append(message)
-            if attempt < max_attempts - 1:
-                time.sleep(2)  # Wait before retrying
-            continue
+            except requests.exceptions.RequestException as e:
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                message = (
+                    f"[{timestamp}] Attempt {attempt + 1} failed to get Bitcoin price: {str(e)}"
+                )
+                logging.warning(message)
+                warnings.append(message)
+                if attempt < max_attempts - 1:
+                    # Wait before retrying with exponential backoff
+                    time.sleep(base_delay ** (attempt + 1))
+                continue
 
     # If all attempts fail, use a fallback price
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    message = f"[{timestamp}] Failed to fetch current Bitcoin price after {max_attempts} attempts. Using fallback price of $100,000"
+    message = (
+        f"[{timestamp}] Failed to fetch current Bitcoin price after {max_attempts} attempts. Using fallback price of $100,000"
+    )
     logging.warning(message)
     warnings.append(message)
     return 100000, warnings  # Default fallback price


### PR DESCRIPTION
## Summary
- reuse a single `requests.Session` for price fetch retries
- add configurable `base_delay` and exponential backoff
- test retry behavior and session reuse

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e5843b1483319b3211621f05f678