### PR TITLE
Enforce exclusive growth parameter for future value

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -17,15 +17,22 @@ class RetirementPlan:
 
 
 def calculate_future_value(
-    monthly_investment, years, annual_growth_rate=None, growth_factor=None
+    monthly_investment, years, *, annual_growth_rate=None, growth_factor=None
 ):
-    """Calculate future value of regular monthly investments with monthly compounding"""
+    """Calculate future value of regular monthly investments with monthly compounding.
+
+    Exactly one of ``annual_growth_rate`` or ``growth_factor`` must be provided.
+    """
+    if (annual_growth_rate is None) == (growth_factor is None):
+        raise ValueError(
+            "Provide exactly one of annual_growth_rate or growth_factor"
+        )
     if growth_factor is not None:
         if years <= 0:
             annual_growth_rate = 0
         else:
             annual_growth_rate = (growth_factor ** (1 / years) - 1) * 100
-    if annual_growth_rate in (None, 0):
+    if annual_growth_rate == 0:
         return monthly_investment * years * 12
     monthly_rate = annual_growth_rate / 100 / 12
     return monthly_investment * (((1 + monthly_rate) ** (years * 12) - 1) / monthly_rate) * (1 + monthly_rate)
@@ -74,7 +81,9 @@ def calculate_bitcoin_needed(
 
     # Calculate future value of monthly investments in dollars
     future_investment_value = calculate_future_value(
-        monthly_investment, years_until_retirement, growth_factor=growth_factor
+        monthly_investment,
+        years_until_retirement,
+        annual_growth_rate=bitcoin_growth_rate,
     )
 
     # Calculate how many Bitcoin the investments will buy at retirement

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -49,7 +49,9 @@ def test_calculate_bitcoin_needed_equivalence():
         (1 + bitcoin_growth_rate / 100) ** years_until_retirement
     )
     future_investment_value = calculate_future_value(
-        monthly_investment, years_until_retirement, bitcoin_growth_rate
+        monthly_investment,
+        years_until_retirement,
+        annual_growth_rate=bitcoin_growth_rate,
     )
     bitcoin_from_investments = future_investment_value / future_bitcoin_price
     total_bitcoin_holdings = current_holdings + bitcoin_from_investments
@@ -109,3 +111,12 @@ def test_project_holdings_over_time_matches_manual_calculation():
         expected_holdings.append(btc_holdings)
 
     assert holdings == pytest.approx(expected_holdings)
+
+
+def test_calculate_future_value_requires_single_parameter():
+    with pytest.raises(ValueError):
+        calculate_future_value(100, 10)
+    with pytest.raises(ValueError):
+        calculate_future_value(
+            100, 10, annual_growth_rate=5, growth_factor=1.5
+        )


### PR DESCRIPTION
## Summary
- require exactly one of `annual_growth_rate` or `growth_factor` in `calculate_future_value`
- call `calculate_future_value` with a single named parameter in `calculate_bitcoin_needed`
- add tests and adjust existing ones to verify the new behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40167efb083319c612ddddc783620