### PR TITLE
Allow zero monthly investment and adjust validation tests

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -32,3 +32,37 @@ def test_monthly_spending_minimum_passes() -> None:
         "Monthly spending" in error for error in errors
     ), "Monthly spending at SPENDING_MIN should pass validation"
 
+
+def test_zero_monthly_investment_allowed_with_positive_growth() -> None:
+    errors = validate_inputs(
+        DEFAULT_CURRENT_AGE,
+        DEFAULT_RETIREMENT_AGE,
+        DEFAULT_LIFE_EXPECTANCY,
+        SPENDING_MIN,
+        DEFAULT_BITCOIN_GROWTH_RATE,
+        DEFAULT_INFLATION_RATE,
+        DEFAULT_CURRENT_HOLDINGS,
+        0.0,
+    )
+
+    assert not errors, (
+        "Zero monthly investment should pass validation even when growth rate is positive"
+    )
+
+
+def test_negative_monthly_investment_fails() -> None:
+    errors = validate_inputs(
+        DEFAULT_CURRENT_AGE,
+        DEFAULT_RETIREMENT_AGE,
+        DEFAULT_LIFE_EXPECTANCY,
+        SPENDING_MIN,
+        DEFAULT_BITCOIN_GROWTH_RATE,
+        DEFAULT_INFLATION_RATE,
+        DEFAULT_CURRENT_HOLDINGS,
+        -1.0,
+    )
+
+    assert any(
+        "Monthly investment" in error for error in errors
+    ), "Negative monthly investment should fail validation"
+

--- a/validation.py
+++ b/validation.py
@@ -30,7 +30,7 @@ def validate_inputs(current_age, retirement_age, life_expectancy, monthly_spendi
     if monthly_investment < RATE_MIN:
         errors.append("Monthly investment cannot be negative")
 
-    if bitcoin_growth_rate > RATE_MIN and monthly_investment == RATE_MIN:
-        errors.append("Monthly investment must be positive if growth rate is positive")
+    # Zero monthly investment is allowed regardless of growth rate. Negative
+    # values remain invalid and are handled above.
 
     return errors


### PR DESCRIPTION
## Summary
- allow a monthly investment of zero even when bitcoin growth rate is positive
- add tests covering zero and negative monthly investment scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40533ecec8331b299ea6c2a0da702