### PR TITLE
Handle empty scenario comparisons

### DIFF
--- a/visualization.py
+++ b/visualization.py
@@ -74,6 +74,15 @@ def compare_scenarios(scenarios: list[dict]) -> None:
     st.subheader("Scenario Comparison")
     st.markdown("Compare different retirement plans side-by-side.")
 
+    compare_clicked = st.button("Compare Scenarios", disabled=not scenarios)
+
+    if not scenarios:
+        st.info("No scenarios to compare.")
+        return
+
+    if not compare_clicked:
+        return
+
     # Create a DataFrame from the scenarios list
     df = pd.DataFrame(scenarios)
 


### PR DESCRIPTION
## Summary
- Show informative message when no scenarios exist and stop early in `compare_scenarios`
- Add comparison button that is disabled until scenarios are available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a406c3ce648331aa670fcee06b97a3