### PR TITLE
refactor: simplify progress visualization interface

### DIFF
--- a/main.py
+++ b/main.py
@@ -213,15 +213,8 @@ def render_results(plan, inputs, current_bitcoin_price):
         st.write(result)
 
         show_progress_visualization(
+            holdings_series,
             current_age=inputs["current_age"],
-            retirement_age=inputs["retirement_age"],
-            life_expectancy=life_expectancy,
-            bitcoin_growth_rate=inputs["bitcoin_growth_rate"],
-            inflation_rate=inputs["inflation_rate"],
-            current_holdings=inputs["current_holdings"],
-            monthly_investment=inputs["monthly_investment"],
-            monthly_spending=inputs["monthly_spending"],
-            current_bitcoin_price=current_bitcoin_price,
         )
 
     st.warning(

--- a/tests/test_render_results.py
+++ b/tests/test_render_results.py
@@ -26,7 +26,7 @@ class DummyStreamlit:
 
 def test_render_results_returns_health_score(monkeypatch):
     monkeypatch.setattr(main, "st", DummyStreamlit())
-    monkeypatch.setattr(main, "show_progress_visualization", lambda **kwargs: None)
+    monkeypatch.setattr(main, "show_progress_visualization", lambda *args, **kwargs: None)
     monkeypatch.setattr(main, "project_holdings_over_time", lambda **kwargs: [3, 2, 1, 0])
 
     plan = RetirementPlan(

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -28,6 +28,7 @@ def test_progress_visualization_smoke():
         assert show(series) is None  # Precomputed holdings
         assert (
             show(
+                None,
                 current_age=35,
                 retirement_age=65,
                 life_expectancy=85,

--- a/visualization.py
+++ b/visualization.py
@@ -8,8 +8,7 @@ from calculations import project_holdings_over_time
 
 
 def show_progress_visualization(
-    holdings: Sequence | None = None,
-    *,
+    holdings: Sequence | None,
     current_age: int | None = None,
     retirement_age: int | None = None,
     life_expectancy: int | None = None,
@@ -22,14 +21,13 @@ def show_progress_visualization(
 ) -> None:
     """Visualize projected Bitcoin holdings over time.
 
-    Parameters can be supplied either as a precomputed ``holdings`` series or
-    individually to run :func:`project_holdings_over_time`. When using the
-    second form all parameters are required.
+    The first argument is a holdings sequence representing BTC holdings by age.
+    If ``holdings`` is ``None`` the sequence will be derived from the supplied
+    parameters via :func:`project_holdings_over_time`. When only a holdings
+    series is provided the ages are inferred from the series itself.
     """
 
-    if holdings is not None:
-        ages = list(range(len(holdings)))
-    else:
+    if holdings is None:
         required = [
             current_age,
             retirement_age,
@@ -56,8 +54,18 @@ def show_progress_visualization(
             monthly_spending,
             current_bitcoin_price,
         )
+    else:
+        if isinstance(holdings, pd.Series):
+            ages = holdings.index
+            holdings = holdings.values
+        else:
+            holdings = list(holdings)
+            if current_age is not None:
+                ages = range(current_age, current_age + len(holdings))
+            else:
+                ages = range(len(holdings))
 
-    df = pd.DataFrame({"Age": ages, "BTC Holdings": holdings})
+    df = pd.DataFrame({"Age": list(ages), "BTC Holdings": list(holdings)})
     fig = px.line(df, x="Age", y="BTC Holdings")
     st.plotly_chart(fig, use_container_width=True)
 


### PR DESCRIPTION
## Summary
- refactor `show_progress_visualization` to take holdings series first and infer ages
- update results rendering to call visualization with precomputed series
- adjust tests for new visualization signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5714fb7e0833180c3d11e0af498fb