### PR TITLE
Style progress visualization line chart

### DIFF
--- a/visualization.py
+++ b/visualization.py
@@ -67,6 +67,12 @@ def show_progress_visualization(
 
     df = pd.DataFrame({"Age": list(ages), "BTC Holdings": list(holdings)})
     fig = px.line(df, x="Age", y="BTC Holdings")
+    fig.update_traces(
+        line_color="rgba(253, 150, 68, 1.0)",
+        fill="tozeroy",
+        fillcolor="rgba(253, 150, 68, 1.0)",
+        opacity=0.5
+    )
     st.plotly_chart(fig, use_container_width=True)
 
 def compare_scenarios(scenarios: list[dict]) -> None:


### PR DESCRIPTION
## Summary
- style the progress visualization chart with orange line and filled area

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab447faa508331b7c23bb575185680