### PR TITLE
Switch Bitcoin price API to mempool.space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project loosely follows the spirit of Keep a Changelog and Semantic Version
 - Display yearly expenses in Bitcoin terms on the retirement chart.
 - Added emojis, just because.
 - Added current Bitcoin price below page title. Removed unnecessary Streamlit elements from header. Added calculator methodology expander to main page.
+- Switched Bitcoin price source to mempool.space API.
 
 ## 2025-08-24
 

--- a/tests/test_render_results.py
+++ b/tests/test_render_results.py
@@ -9,6 +9,7 @@ class DummyCtx:
     def __exit__(self, exc_type, exc, tb):
         pass
 
+
 class DummyStreamlit:
     def expander(self, *args, **kwargs):
         return DummyCtx()
@@ -21,6 +22,8 @@ class DummyStreamlit:
     def warning(self, *args, **kwargs):
         pass
     def metric(self, *args, **kwargs):
+        pass
+    def info(self, *args, **kwargs):
         pass
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,7 +68,7 @@ def test_get_bitcoin_price_malformed_json(monkeypatch):
     assert len(warnings) == 2
 
 
-def test_get_bitcoin_price_missing_price(monkeypatch):
+def test_get_bitcoin_price_missing_usd(monkeypatch):
     class MockResponse:
         def raise_for_status(self):
             pass
@@ -92,6 +92,58 @@ def test_get_bitcoin_price_missing_price(monkeypatch):
 
     assert price == 100000
     assert len(warnings) == 2
+
+
+def test_get_bitcoin_price_non_positive_usd(monkeypatch):
+    class MockResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"USD": 0}
+
+    class MockSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, *args, **kwargs):
+            return MockResponse()
+
+    monkeypatch.setattr(requests, "Session", MockSession)
+
+    price, warnings = get_bitcoin_price(max_attempts=1)
+
+    assert price == 100000
+    assert len(warnings) == 2
+
+
+def test_get_bitcoin_price_success(monkeypatch):
+    class MockResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"USD": 12345.67}
+
+    class MockSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, *args, **kwargs):
+            return MockResponse()
+
+    monkeypatch.setattr(requests, "Session", MockSession)
+
+    price, warnings = get_bitcoin_price(max_attempts=1)
+
+    assert price == 12345.67
+    assert warnings == []
 
 
 def test_get_bitcoin_price_quick_fail(monkeypatch):

--- a/utils.py
+++ b/utils.py
@@ -35,7 +35,7 @@ def get_bitcoin_price(
     jitter: float = 0,
     quick_fail: bool = False,
 ):
-    """Fetch the current Bitcoin price from DIA API with retry logic.
+    """Fetch the current Bitcoin price from the mempool.space API with retry logic.
 
     Args:
         max_attempts (int): Maximum number of attempts to fetch the price.
@@ -52,9 +52,7 @@ def get_bitcoin_price(
             or fallback price if all attempts fail, and warnings is a list of
             warning messages generated during the process.
     """
-    dia_api_url = (
-        "https://api.diadata.org/v1/assetQuotation/Bitcoin/0x0000000000000000000000000000000000000000"
-    )
+    mempool_api_url = "https://mempool.space/api/v1/prices"
     timeout = 10  # seconds
     warnings = []
 
@@ -62,14 +60,13 @@ def get_bitcoin_price(
         attempts = 1 if quick_fail else max_attempts
         for attempt in range(attempts):
             try:
-                response = session.get(dia_api_url, timeout=timeout)
+                response = session.get(mempool_api_url, timeout=timeout)
                 response.raise_for_status()
 
                 data = response.json()
-                current_price = float(data["Price"])
-
+                current_price = float(data["USD"])
                 if current_price <= 0:
-                    raise ValueError("Received invalid price")
+                    raise KeyError("USD price not found or invalid")
 
                 return current_price, warnings
 


### PR DESCRIPTION
## Summary
- fetch Bitcoin price from mempool.space instead of DIA
- validate USD field and handle missing or invalid values
- test new price parsing and fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad2fd761f88331b893c72b05b15c13