### PR TITLE
docs: clarify BTC need calculation

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -84,12 +84,20 @@ def calculate_bitcoin_needed(
         annual_expense_at_retirement, retirement_duration, inflation_rate
     )
 
-    # Calculate future Bitcoin price at retirement
-    growth_factor = (1 + bitcoin_growth_rate / 100) ** years_until_retirement
-    future_bitcoin_price = current_bitcoin_price * growth_factor
+    # Project Bitcoin prices and yearly expenses across retirement
+    growth_factor = 1 + bitcoin_growth_rate / 100
+    inflation_multiplier = 1 + inflation_rate / 100
+    retirement_years = np.arange(
+        years_until_retirement, years_until_retirement + retirement_duration
+    )
+    projected_prices = current_bitcoin_price * growth_factor ** retirement_years
+    yearly_expenses = monthly_spending * 12 * inflation_multiplier ** retirement_years
 
-    # Calculate Bitcoin needed at retirement
-    bitcoin_needed = total_retirement_expenses / future_bitcoin_price
+    # Sum yearly BTC requirements to find total Bitcoin needed
+    bitcoin_needed = float(np.sum(yearly_expenses / projected_prices))
+
+    # Bitcoin price at the moment of retirement
+    future_bitcoin_price = current_bitcoin_price * growth_factor ** years_until_retirement
 
     # Calculate future value of monthly investments in dollars
     future_investment_value = calculate_future_value(

--- a/main.py
+++ b/main.py
@@ -311,12 +311,12 @@ def render_calculation_methodology():
            - `Total_expenses = A * ((1 + r)^n - 1) / r * (1 + r)`
              where `n` is years in retirement.
 
-        4) **What will Bitcoin's price be at retirement?** The calculator projects what one Bitcoin may cost at retirement by applying a user-specified growth rate.
-           - `BTC_future_price = BTC_current_price * (1 + g)^y`
-             where `g` is the annual BTC growth rate.
+        4) **How do Bitcoin prices evolve during retirement?** The calculator projects a BTC price for every year using the growth factor.
+           - `BTC_price(year) = BTC_current_price * growth_factor^year`
+             where `growth_factor = 1 + g` and `g` is the annual BTC growth rate.
 
-        5) **How many BTC would cover retirement expenses?** Dividing the total retirement expenses by the future Bitcoin price yields how many coins are needed.
-           - `BTC_needed = Total_expenses / BTC_future_price`
+        5) **How many BTC will cover retirement expenses?** Each year's inflated expenses are divided by that year's projected BTC price, and all yearly BTC amounts are summed.
+           - `BTC_needed = Σ (inflated_expense_year / BTC_price_year)`
 
         6) **If you invest monthly until retirement, how much will you hold??** If you invest every month, their future value is computed with monthly compounding.
            - `FV_contributions = P * ((1 + i)^(12y) - 1) / i * (1 + i)`

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+import numpy as np
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -55,7 +56,15 @@ def test_calculate_bitcoin_needed_equivalence():
     )
     bitcoin_from_investments = future_investment_value / future_bitcoin_price
     total_bitcoin_holdings = current_holdings + bitcoin_from_investments
-    bitcoin_needed = total_retirement_expenses / future_bitcoin_price
+
+    growth_factor = 1 + bitcoin_growth_rate / 100
+    inflation_multiplier = 1 + inflation_rate / 100
+    retirement_years = np.arange(
+        years_until_retirement, years_until_retirement + retirement_duration
+    )
+    projected_prices = current_bitcoin_price * growth_factor ** retirement_years
+    yearly_expenses = monthly_spending * 12 * inflation_multiplier ** retirement_years
+    bitcoin_needed = np.sum(yearly_expenses / projected_prices)
 
     assert plan.annual_expense_at_retirement == pytest.approx(
         annual_expense_at_retirement


### PR DESCRIPTION
## Summary
- explain Bitcoin price projections and per-year expense conversion in methodology
- project yearly BTC prices and sum yearly BTC requirements when computing bitcoin_needed
- adapt unit test to match per-year calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad3bb0be4083319bc72304cf5ef3eb