### PR TITLE
Add Monte Carlo simulation option and fan chart

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -1,0 +1,97 @@
+import numpy as np
+
+def simulate_regime_shift_returns(years: int, n_sims: int, seed: int | None = None) -> np.ndarray:
+    """Simulate annual return factors using a simple two-regime model.
+
+    Parameters
+    ----------
+    years:
+        Number of years to simulate.
+    n_sims:
+        Number of simulation paths.
+    seed:
+        Optional random seed for reproducibility.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(n_sims, years)`` containing multiplicative return
+        factors (``1 + r``) for each year and simulation.
+    """
+    rng = np.random.default_rng(seed)
+    # Bernoulli draw for bull (True) or bear (False) regime
+    regimes = rng.random((n_sims, years)) < 0.5
+    bull = rng.normal(0.3, 0.2, size=(n_sims, years))
+    bear = rng.normal(-0.1, 0.25, size=(n_sims, years))
+    returns = np.where(regimes, bull, bear)
+    # Convert to growth factors
+    return 1 + returns
+
+
+def simulate_holdings_paths(
+    return_factors: np.ndarray,
+    current_age: int,
+    retirement_age: int,
+    current_holdings: float,
+    monthly_investment: float,
+    monthly_spending: float,
+    current_bitcoin_price: float,
+) -> tuple[np.ndarray, float]:
+    """Simulate BTC holdings paths given return factors.
+
+    Parameters
+    ----------
+    return_factors:
+        Array of shape ``(n_sims, years)`` of annual growth factors.
+    current_age, retirement_age:
+        Ages defining the simulation horizon and when spending begins.
+    current_holdings:
+        Current BTC holdings.
+    monthly_investment:
+        USD invested every month before retirement.
+    monthly_spending:
+        USD spent every month after retirement.
+    current_bitcoin_price:
+        Present BTC price used as the starting point.
+
+    Returns
+    -------
+    tuple
+        ``(paths, prob_not_run_out)`` where ``paths`` is an array of BTC
+        holdings for each simulation and year and ``prob_not_run_out`` is the
+        probability that funds remain positive through retirement.
+    """
+    n_sims, years = return_factors.shape
+    prices = current_bitcoin_price * np.cumprod(return_factors, axis=1)
+
+    years_until_retirement = retirement_age - current_age
+    holdings = np.zeros((n_sims, years))
+    h = np.full(n_sims, current_holdings, dtype=float)
+
+    invest_btc = (
+        (monthly_investment * 12) / prices[:, :years_until_retirement]
+        if years_until_retirement > 0
+        else np.empty((n_sims, 0))
+    )
+    spend_btc = (
+        (monthly_spending * 12) / prices[:, years_until_retirement:]
+        if years_until_retirement < years
+        else np.empty((n_sims, 0))
+    )
+
+    for t in range(years):
+        if t < years_until_retirement:
+            h = h + invest_btc[:, t]
+        else:
+            idx = t - years_until_retirement
+            if idx < spend_btc.shape[1]:
+                h = np.maximum(h - spend_btc[:, idx], 0.0)
+        holdings[:, t] = h
+
+    after_retirement = holdings[:, years_until_retirement:]
+    if after_retirement.size:
+        not_run_out = np.all(after_retirement > 0, axis=1)
+        prob_not_run_out = float(np.mean(not_run_out))
+    else:
+        prob_not_run_out = 1.0
+    return holdings, prob_not_run_out

--- a/tests/test_render_results.py
+++ b/tests/test_render_results.py
@@ -51,6 +51,6 @@ def test_render_results_returns_health_score(monkeypatch):
         "monthly_investment": 0.0,
         "monthly_spending": 0.0,
     }
-    score, details = main.render_results(plan, inputs, 1.0)
+    score, details = main.render_results(plan, inputs, 1.0, None)
     assert score == compute_health_score_basic(1.5, 2)
     assert details["funding_ratio"] == 1.5

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,5 +1,6 @@
 import importlib
 import types
+import numpy as np
 
 viz = importlib.import_module("visualization")
 calc = importlib.import_module("calculations")
@@ -41,3 +42,29 @@ def test_progress_visualization_smoke():
             )
             is None
         )
+
+
+def test_fan_chart_smoke(monkeypatch):
+    captured = []
+    fake_st = types.SimpleNamespace(plotly_chart=lambda fig, *a, **k: captured.append(fig))
+    monkeypatch.setattr(viz, "st", fake_st)
+
+    paths = np.zeros((5, 3))
+    assert viz.show_fan_chart(paths, 30) is None
+
+    fig = captured.pop()
+    expected = {
+        "p10": ("rgba(255, 89, 94, 1)", "rgba(255, 89, 94, 0.2)"),
+        "p25": ("rgba(255, 202, 58, 1)", "rgba(255, 202, 58, 0.2)"),
+        "p50": ("rgba(138, 201, 38, 1)", "rgba(138, 201, 38, 0.2)"),
+        "p75": ("rgba(25, 130, 196, 1)", "rgba(25, 130, 196, 0.2)"),
+        "p90": ("rgba(106, 76, 147, 1)", "rgba(106, 76, 147, 0.2)"),
+    }
+    for trace in fig.data:
+        line_color, fill_color = expected[trace.name]
+        assert trace.line.color == line_color
+        assert trace.fill == "tozeroy"
+        assert trace.fillcolor == fill_color
+
+    # Single path should also be handled gracefully
+    assert viz.show_fan_chart(np.zeros(3), 30) is None


### PR DESCRIPTION
## Summary
- Add Monte Carlo simulation toggle and simulation count to the retirement calculator
- Implement regime shift return and holdings path simulators
- Display probability of not running out and fan chart in results
- Fix fan chart rendering by computing age ranges and accepting single-path inputs
- Customize fan chart percentile lines with specified color palette and translucent fills

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae01fbdaac833198ac8ba621952a7c